### PR TITLE
fix compile problems on mac

### DIFF
--- a/concurrent_queue.hpp
+++ b/concurrent_queue.hpp
@@ -22,7 +22,7 @@ public:
 
     bool empty() const
     {
-        boost::lock_guard lock(the_mutex);
+        boost::lock_guard<boost::mutex> lock(the_mutex);
         return the_queue.empty();
     }
 

--- a/cpplog.hpp
+++ b/cpplog.hpp
@@ -246,7 +246,7 @@ namespace cpplog
 #ifndef CPPLOG_NO_SYSTEM_IDS
 			// Get process/thread ID.
 			m_logData->processId	= boost::interprocess::detail::get_current_process_id();
-			m_logData->threadId		= boost::interprocess::detail::get_current_thread_id();
+			m_logData->threadId		= (unsigned long)boost::interprocess::detail::get_current_thread_id();
 #endif
 		}
 

--- a/main.cpp
+++ b/main.cpp
@@ -22,7 +22,7 @@ void getLogHeader(string& outString, loglevel_t level, const char* file, unsigne
 
 #ifndef CPPLOG_NO_SYSTEM_IDS
 	unsigned long processId	= get_current_process_id();
-	unsigned long threadId	= get_current_thread_id();
+	unsigned long threadId	= (unsigned long)get_current_thread_id();
 
 	outStream << "[" 
 			  << right << setfill('0') << setw(8) << hex 


### PR DESCRIPTION
the type of return value of current_thread_id() is _opaque_pthread_t\* on gcc
