### PR TITLE
compile failed on OSX

### DIFF
--- a/cpplog.hpp
+++ b/cpplog.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <strstream>
 #include <fstream>
+#include <sstream>
 #include <cstring>
 #include <ctime>
 #include <vector>


### PR DESCRIPTION
due to a missing sstream include in cpplog.hpp
