### PR TITLE
Add support for custom log formatting

### DIFF
--- a/cpplog.hpp
+++ b/cpplog.hpp
@@ -313,10 +313,13 @@ namespace cpplog
     {
     private:
         BaseLogger*     m_logger;
-        LogData*        m_logData;
         bool            m_flushed;
         bool            m_deleteMessage;
 
+    protected:
+        LogData*        m_logData;
+
+    private:
         // Flag for if a fatal message has been logged already.
         // This prevents us from calling exit(), which calls something,
         // which then logs a fatal message, which cause an infinite loop.
@@ -338,10 +341,10 @@ namespace cpplog
             Init(file, line, logLevel);
         }
 
-        LogMessage(const char* file, unsigned int line, loglevel_t logLevel, BaseLogger& outputLogger)
+        LogMessage(const char* file, unsigned int line, loglevel_t logLevel, BaseLogger& outputLogger, bool useDefaultLogFormat=true)
             : m_logger(&outputLogger)
         {
-            Init(file, line, logLevel);
+            Init(file, line, logLevel, useDefaultLogFormat);
         }
 
         virtual ~LogMessage()
@@ -359,8 +362,25 @@ namespace cpplog
             return m_logData->stream;
         }
 
+    protected:
+        virtual void InitLogMessage()
+        {
+            // Log process ID and thread ID.
+#ifdef CPPLOG_SYSTEM_IDS
+            m_logData->stream << "["
+                        << std::right << std::setfill('0') << std::setw(8) << std::hex
+                        << m_logData->processId << ".";
+            helpers::print_thread_id(m_logData->stream, m_logData->threadId);
+            m_logData->stream << "] ";
+#endif
+
+            m_logData->stream << std::setfill(' ') << std::setw(5) << std::left << std::dec
+                        << LogMessage::getLevelName(m_logData->level) << " - "
+                        << m_logData->fileName << "(" << m_logData->line << "): ";
+        }
+
     private:
-        void Init(const char* file, unsigned int line, loglevel_t logLevel)
+        void Init(const char* file, unsigned int line, loglevel_t logLevel, bool useDefaultLogFormat=true)
         {
             m_logData = new LogData(logLevel);
             m_flushed = false;
@@ -382,23 +402,10 @@ namespace cpplog
             m_logData->threadId     = helpers::get_thread_id();
 #endif // CPPLOG_SYSTEM_IDS
 
-            InitLogMessage();
-        }
-
-        void InitLogMessage()
-        {
-            // Log process ID and thread ID.
-#ifdef CPPLOG_SYSTEM_IDS
-            m_logData->stream << "["
-                        << std::right << std::setfill('0') << std::setw(8) << std::hex
-                        << m_logData->processId << ".";
-            helpers::print_thread_id(m_logData->stream, m_logData->threadId);
-            m_logData->stream << "] ";
-#endif
-
-            m_logData->stream << std::setfill(' ') << std::setw(5) << std::left << std::dec
-                        << LogMessage::getLevelName(m_logData->level) << " - "
-                        << m_logData->fileName << "(" << m_logData->line << "): ";
+            if (useDefaultLogFormat)
+            {
+                InitLogMessage();
+            }
         }
 
         void Flush()
@@ -469,7 +476,7 @@ namespace cpplog
     // Generic class - logs to a given std::ostream.
     class OstreamLogger : public BaseLogger
     {
-    private:
+    protected:
         std::ostream&   m_logStream;
 
     public:
@@ -1006,7 +1013,10 @@ namespace cpplog
 // Our logging macros.
 
 // Default macros - log, and don't log something.
+// Allow custom log message formatting
+#ifndef LOG_LEVEL
 #define LOG_LEVEL(level, logger)    cpplog::LogMessage(__FILE__, __LINE__, (level), logger).getStream()
+#endif
 #define LOG_NOTHING(level, logger)  true ? (void)0 : cpplog::helpers::VoidStreamClass() & LOG_LEVEL(level, logger)
 
 // Series of debug macros, depending on what we log.

--- a/examples/customlogformat.cpp
+++ b/examples/customlogformat.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+
+#ifdef WIN32
+#define __func__ __FUNCTION__
+#endif
+
+// This define must be before including "cpplog.hpp"
+#define LOG_LEVEL(level, logger) CustomLogMessage(__FILE__, __func__, __LINE__, (level), logger).getStream()
+#include "../cpplog.hpp"
+
+class CustomLogMessage : public cpplog::LogMessage
+{
+public:
+    CustomLogMessage(const char* file, const char* function,
+        unsigned int line, cpplog::loglevel_t logLevel,
+        cpplog::BaseLogger &outputLogger)
+    : cpplog::LogMessage(file, line, logLevel, outputLogger, false),
+      m_function(function)
+    {
+        InitLogMessage();
+    }
+
+    static const char* shortLogLevelName(cpplog::loglevel_t logLevel)
+    {
+        switch( logLevel )
+        {
+            case LL_TRACE: return "T";
+            case LL_DEBUG: return "D";
+            case LL_INFO:  return "I";
+            case LL_WARN:  return "W";
+            case LL_ERROR: return "E";
+            case LL_FATAL: return "F";
+            default:       return "O";
+        };
+    }
+
+protected:
+    virtual void InitLogMessage()
+    {
+        m_logData->stream
+            << "["
+            << m_logData->fileName << ":"
+            << m_function          << ":"
+            << m_logData->line
+            << "]["
+            << shortLogLevelName(m_logData->level)
+            << "] ";
+    }
+private:
+    const char *m_function;
+};
+
+int main()
+{
+    cpplog::StdErrLogger slog;
+    LOG_WARN(slog) << "Custom log format.";
+
+    return 0;
+}
+


### PR DESCRIPTION
This can be achieved by:
1. Subclass cpplog::LogMessage
2. Implement InitLogMessage
3. Call InitLogMessage from the constructor
4. Redefine the LOG_LEVEL macro

See examples/customlogformat.cpp
