### PR TITLE
Avoid redefining min/max

### DIFF
--- a/outputdebugstream.hpp
+++ b/outputdebugstream.hpp
@@ -2,6 +2,7 @@
 #ifndef _OUTPUT_DEBUG_STREAM_H
 #define _OUTPUT_DEBUG_STREAM_H
 
+#define NOMINMAX
 #include <windows.h>
 
 template <class _Elem>


### PR DESCRIPTION
windows.h defines min/max macros which conflict with std::min/std::max
and lead to nasty and confusing compilation errors (see for example
http://stackoverflow.com/questions/11544073/how-do-i-deal-with-the-max-m
acro-in-windows-h-colliding-with-max-in-std).  This prevents min/max
from being defined by windows.h
